### PR TITLE
fix: tabschema param needs quotes

### DIFF
--- a/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/config/querys/DB2Query.java
+++ b/mybatis-plus-generator/src/main/java/com/baomidou/mybatisplus/generator/config/querys/DB2Query.java
@@ -25,13 +25,13 @@ public class DB2Query extends AbstractDbQuery {
 
     @Override
     public String tablesSql() {
-        return "SELECT * FROM SYSCAT.TABLES where tabschema=%s";
+        return "SELECT * FROM SYSCAT.TABLES where tabschema='%s'";
     }
 
 
     @Override
     public String tableFieldsSql() {
-        return "SELECT * FROM syscat.columns WHERE tabschema=%s AND tabname='%s'";
+        return "SELECT * FROM syscat.columns WHERE tabschema='%s' AND tabname='%s'";
     }
 
 


### PR DESCRIPTION
### 该Pull Request关联的Issue
无


### 修改描述
获取DB2表定义数据时，SQL中的tabschema缺少单引号


### 测试用例
无


### 修复效果的截屏
修复前：DB2环境报错
修复后：DB2可正常获取表定义数据

